### PR TITLE
SUPP0RT-1037: remove todo handle pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - [#103](https://github.com/os2display/display-client/pull/103)
-Removed "todo handle pagination" and handles pagination.
+Update PullStrategy to handle pagination.
 
 ## [1.2.3] - 2023-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- [#103](https://github.com/os2display/display-client/pull/103)
+Removed "todo handle pagination" and handles pagination.
 
 ## [1.2.3] - 2023-03-24
 


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/SUPP0RT-1037

#### Description

Use the "page=x" in url for getting more entries. not sure what the responseData['hydra:view']['hydra:next']-notation covers but I have boldly assumed this was trying to handle pagination, and I've removed it.

Added "continueLoop", because vscode said "Type 'boolean' is not assignable to type 'string'." - technically a ts-error, but this i prettier.

#### Screenshot of the result

n/a 

#### Checklist

- [x] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

n/a