### PR TITLE
DISPLAY-986: Change docker image name to match repository name

### DIFF
--- a/.github/workflows/docker_build_develop.yml
+++ b/.github/workflows/docker_build_develop.yml
@@ -26,7 +26,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: os2display/os2display-client
+          images: os2display/display-client
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/docker_build_tag.yml
+++ b/.github/workflows/docker_build_tag.yml
@@ -22,7 +22,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: os2display/os2display-client
+          images: os2display/display-client
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- [#109](https://github.com/os2display/display-client/pull/109)
+  Change docker image name from `os2display/os2display-client` to `os2display/display-client` to match image name and repository name
+
 ## [1.2.6] - 2023-06-12
 
 - [#105](https://github.com/os2display/display-client/pull/105)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ docker compose run cypress run
 
 ## Build for production
 
-Github actions will build both docker images published to [docker hub](https://hub.docker.com/repository/docker/os2display/os2display-client/general) and release assets published as [github releases](https://github.com/os2display/display-client/releases). To run the display client choose which option suits you and download it.
+Github actions will build both docker images published to [docker hub](https://hub.docker.com/repository/docker/os2display/display-client/general) and release assets published as [github releases](https://github.com/os2display/display-client/releases). To run the display client choose which option suits you and download it.
 
 If you wish to do your own production build, you need to do
 ```shell

--- a/infrastructure/run.sh
+++ b/infrastructure/run.sh
@@ -7,6 +7,6 @@ APP_RELEASE_TIME=$(date)
 APP_VERSION=develop
 VERSION=alpha
 
-docker build --pull --no-cache --build-arg APP_VERSION=${APP_VERSION} --build-arg APP_RELEASE_TIMESTAMP="${APP_RELEASE_TIMESTAMP}" --build-arg APP_RELEASE_TIME="${APP_RELEASE_TIME}" --tag=os2display/os2display-client:${VERSION} --file="Dockerfile" .
+docker build --pull --no-cache --build-arg APP_VERSION=${APP_VERSION} --build-arg APP_RELEASE_TIMESTAMP="${APP_RELEASE_TIMESTAMP}" --build-arg APP_RELEASE_TIME="${APP_RELEASE_TIME}" --tag=os2display/display-client:${VERSION} --file="Dockerfile" .
 
-# docker push os2display/os2display-client:${VERSION}
+# docker push os2display/display-client:${VERSION}


### PR DESCRIPTION
#### Link to ticket

DISPLAY-986

#### Description

Change docker image name from `os2display/os2display-client` to `os2display/display-client` to match image name and repository name

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
