### PR TITLE
DISPLAY-1018: Remove trailing slashes from example config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- [#115](https://github.com/os2display/display-client/pull/115)
+  Removed trailing slash from URLs in `/public/example_config.json` given that oor fetch code expects no trailing slash
 
 ## [1.3.4] - 2023-07-13
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,35 @@
 This is the client that will display slides from OS2Display.
 See [https://github.com/os2display/display-docs/blob/main/client.md](https://github.com/os2display/display-docs/blob/main/client.md) for more info about the client.
 
+## Config
+The client can be configured by creating `public/config.json` with relevant values.
+See `public/example_config.json` for values.
+
+```json
+{
+  "apiEndpoint": "",
+  "authenticationEndpoint": "/v1/authentication/screen",
+  "authenticationRefreshTokenEndpoint": "/v1/authentication/token/refresh",
+  "dataStrategy": {
+    "type": "pull",
+    "config": {
+      "interval": 30000,
+      "endpoint": ""
+    }
+  },
+  "colorScheme": {
+    "type": "library",
+    "lat": 56.0,
+    "lng": 10.0
+  },
+  "schedulingInterval": 60000,
+  "debug": false
+}
+```
+All endpoint should be configured with out a trailing slash. The endpoints `apiEndpoint` and `dataStrategy.config.endpoint` can be
+left empty if the api is hosted from the root of the same domain as the client. E.g. if the api is at https://example.org and the client is at
+https://example.org/client
+
 ## Docker development setup
 
 Start docker setup

--- a/infrastructure/itkdev/etc/confd/templates/config.tmpl
+++ b/infrastructure/itkdev/etc/confd/templates/config.tmpl
@@ -1,12 +1,12 @@
 {
-  "apiEndpoint": "{{ getenv "APP_API_ENDPOINT" "/" }}",
+  "apiEndpoint": "{{ getenv "APP_API_ENDPOINT" "" }}",
   "authenticationEndpoint": "{{ getenv "APP_API_AUTHENTICATION_ENDPOINT" "/v1/authentication/token" }}",
   "authenticationRefreshTokenEndpoint": "{{ getenv "APP_API_AUTHENTICATION_REFRESH_ENDPOINT" "/v1/authentication/token/refresh" }}",
   "dataStrategy": {
     "type": "pull",
     "config": {
       "interval": {{ getenv "APP_DATA_PULL_INTERVAL" "30000" }},
-      "endpoint": "{{ getenv "APP_API_PATH" "/" }}"
+      "endpoint": "{{ getenv "APP_API_PATH" "" }}"
     }
   },
   "colorScheme": {

--- a/public/example_config.json
+++ b/public/example_config.json
@@ -1,12 +1,12 @@
 {
-  "apiEndpoint": "/",
+  "apiEndpoint": "",
   "authenticationEndpoint": "/v1/authentication/screen",
   "authenticationRefreshTokenEndpoint": "/v1/authentication/token/refresh",
   "dataStrategy": {
     "type": "pull",
     "config": {
       "interval": 30000,
-      "endpoint": "/"
+      "endpoint": ""
     }
   },
   "colorScheme": {


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/DISPLAY-1018

#### Description

Have updated `/public/example_config.json` to not have trailing spaces for any endpoints. In the example we had `"apiEndpoint": "/"` to indicate the api being at the root of the same domain as the client. However when constructing thje URLs for the `fetch()` calls in the code we do not allow for trailing slashes.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
