### PR TITLE
DISPLAY-1039: release 1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+
+## [1.3.5] - 2023-09-14
+
 - [#115](https://github.com/os2display/display-client/pull/115)
-  Removed trailing slash from URLs in `/public/example_config.json` given that oor fetch code expects no trailing slash
+  Removed trailing slash from URLs in `/public/example_config.json` given that our fetch code expects no trailing slash
 
 ## [1.3.4] - 2023-07-13
 


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/DISPLAY-1039

#### Description

##### Release 1.3.5

- [#115](https://github.com/os2display/display-client/pull/115)
  Removed trailing slash from URLs in `/public/example_config.json` given that our fetch code expects no trailing slash

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
