### PR TITLE
1453: Avoid null redirect when release.json cannot be retrieved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- [#125](https://github.com/os2display/display-client/pull/125)
+  - Removed React strict mode.
+  - Added null check to release query parameter changes, to avoid redirecting to ?releaseVersion=null&releaseTimestamp=null when release.json cannot be reached (eg. when the internet connection is down).
+
 ## [2.0.2] - 2024-04-25
 
 - [#123](https://github.com/os2display/display-client/pull/123)

--- a/src/app.js
+++ b/src/app.js
@@ -279,18 +279,31 @@ function App() {
   const checkForUpdates = () => {
     Logger.log('info', 'Checking for new release timestamp.');
 
-    ReleaseLoader.loadConfig().then((config) => {
+    ReleaseLoader.loadConfig().then((release) => {
       if (releaseTimestampRef?.current === null) {
-        releaseTimestampRef.current = config.releaseTimestamp;
-      } else if (releaseTimestampRef?.current !== config.releaseTimestamp) {
-        const redirectUrl = new URL(window.location.href);
-        redirectUrl.searchParams.set(
-          'releaseTimestamp',
-          config.releaseTimestamp
-        );
-        redirectUrl.searchParams.set('releaseVersion', config.releaseVersion);
+        releaseTimestampRef.current = release.releaseTimestamp;
+      } else if (releaseTimestampRef?.current !== release.releaseTimestamp) {
+        if (
+          release.releaseTimestamp !== null &&
+          release.releaseVersion !== null
+        ) {
+          const redirectUrl = new URL(window.location.href);
+          redirectUrl.searchParams.set(
+            'releaseTimestamp',
+            release.releaseTimestamp
+          );
+          redirectUrl.searchParams.set(
+            'releaseVersion',
+            release.releaseVersion
+          );
 
-        window.location.replace(redirectUrl);
+          window.location.replace(redirectUrl);
+        } else {
+          Logger.log(
+            'info',
+            'Release timestamp or version null, not redirecting.'
+          );
+        }
       }
     });
   };
@@ -322,13 +335,23 @@ function App() {
       !currentUrl.searchParams.has('releaseTimestamp')
     ) {
       ReleaseLoader.loadConfig().then((release) => {
-        currentUrl.searchParams.set(
-          'releaseTimestamp',
-          release.releaseTimestamp
-        );
-        currentUrl.searchParams.set('releaseVersion', release.releaseVersion);
+        if (
+          release.releaseTimestamp !== null &&
+          release.releaseVersion !== null
+        ) {
+          currentUrl.searchParams.set(
+            'releaseTimestamp',
+            release.releaseTimestamp
+          );
+          currentUrl.searchParams.set('releaseVersion', release.releaseVersion);
 
-        window.history.replaceState(null, '', currentUrl);
+          window.history.replaceState(null, '', currentUrl);
+        } else {
+          Logger.log(
+            'info',
+            'Release timestamp or version null, not setting query parameters.'
+          );
+        }
       });
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,4 @@ import App from './app';
 const container = document.getElementById('root');
 const root = createRoot(container);
 
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+root.render(<App />);


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/1453

#### Description

* Removed React strict mode.
* Added null check to release query parameter changes, to avoid redirecting to ?releaseVersion=null&releaseTimestamp=null when release.json cannot be reached (eg. when the internet connection is down).

#### Checklist

- [ ] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.
